### PR TITLE
Fixed error in section documentation

### DIFF
--- a/src/app/components/sections-page/sections-page.component.html
+++ b/src/app/components/sections-page/sections-page.component.html
@@ -137,12 +137,12 @@
     bytes ban headers
     gnu brute force. All your base are belong to us semaphore exception giga highjack system mailbomb eaten by a
     grue
-    error fopen null. James T. Kirk firewall recursively hello world man pages protected.
+    error fopen null. James T. Kirk firewall recursively hello world man pages protected. uwu
   </ngx-section>
   <app-prism>
 <![CDATA[<ngx-section
   sectionTitle="Attack Details"
-  [showToggle]="false"
+  togglePosition="none"
   [headerToggle]="true">
   Some Content
 </ngx-section>]]>


### PR DESCRIPTION
## Summary

Hi, I noticed that there's a error in section documentation.
It says to hide toggle I must do
```html
<ngx-section
  sectionTitle="Attack Details"
  [showToggle]="false"
  [headerToggle]="true">
  Some Content
</ngx-section>
```
but it appears that [showToggle] is no longer valid attribute of ngx-section. I looked in a code and noticed that in code you used
```html
  togglePosition="none"
```
instead. So I changed it in docs and now it's correct ^^

## Checklist

- [ ] \*Added unit tests
- [ ] \*Added a code reviewer
- [ ] Added changes to `/projects/swimlane/ngx-ui/CHANGELOG.md` under HEAD (Unreleased)
- [x] Updated the demo page
- [ ] Included screenshots of visual changes

_\*required_
